### PR TITLE
Improve compatibility with older auto1111 UI versions

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -11,7 +11,11 @@ from modules import script_callbacks
 
 from scripts.td_abg import get_foreground
 from scripts.convertor import pil2cv
-from modules.paths_internal import extensions_dir
+try:
+    from modules.paths_internal import extensions_dir
+except Exception:
+    from modules.extensions import extensions_dir
+
 from collections import OrderedDict
 
 

--- a/scripts/sa_mask.py
+++ b/scripts/sa_mask.py
@@ -13,8 +13,11 @@ import torch
 from segment_anything import SamAutomaticMaskGenerator, sam_model_registry
 from collections import OrderedDict
 
+try:
+    from modules.paths_internal import extensions_dir
+except Exception:
+    from modules.extensions import extensions_dir
 
-from modules.paths_internal import extensions_dir
 from modules.safe import unsafe_torch_load, load
 from modules.devices import device
 


### PR DESCRIPTION
Hi! 

This changes around a couple of imports to allow this to work on the last commit to the AUTO1111 repo prior to the Gradio upgrade - a lot of users (myself and many colab users included) are still hanging around on the old version for the time being, as many other extensions don't work on 3.23 just yet.

It's just a try/catch on two import statements since the import path for `extensions_dir` moved.

Let me know if I need to change anything? 😄 