### PR TITLE
update image output component

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -79,14 +79,11 @@ def on_ui_tabs():
                 submit = gr.Button(value="Submit")
             with gr.Row():
                 with gr.Column():
-                    with gr.Tab("output"):
-                        output_img = gr.Image()
-                    with gr.Tab("mask"):
-                        output_mask = gr.Image()
+                    gallery = gr.Gallery(label="outputs", show_label=True, elem_id="gallery").style(grid=2)
         submit.click(
             processing, 
             inputs=[input_image, td_abg_enabled, h_split, v_split, n_cluster, alpha, th_rate, cascadePSP_enabled, fast, psp_L, sa_enabled, seg_query, model_name, predicted_iou_threshold, stability_score_threshold, clip_threshold], 
-            outputs=[output_img, output_mask]
+            outputs=gallery
         )
 
     return [(PBRemTools, "PBRemTools", "pbremtools")]


### PR DESCRIPTION
## Why
- output result cut off when submit vertically long image
- `Image` base64 encoded image creates a bit of confusion in UX

<img src="https://user-images.githubusercontent.com/128375799/232323195-a2ffdcc4-f1b0-4ea7-8d6a-6ccaf4372af0.png" width="500">

## What
- replace output `Image` component with `Gallery` component like a A1111 txt2img

<img src="https://user-images.githubusercontent.com/128375799/232323403-368306ff-b50d-4a30-8b34-c5140ccef4dc.png" width="500">

<img src="https://user-images.githubusercontent.com/128375799/232323307-b4f3a5b6-dc43-493b-9998-2ea608fd4014.png" width="500">


Thanks so much for such a awesome convenient tool!