### PR TITLE
Rework UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,9 @@ MANIFEST
 # Jupyter Notebook
 *.ipynb_checkpoints
 *.ipynb:Zone.Identifier
+
+# MyPy
+*/.mypy_cache/
+
+# VS Code
+.vscode/

--- a/install.py
+++ b/install.py
@@ -1,28 +1,37 @@
 import launch
+import sys
 
 if not launch.is_installed("onnx"):
-    launch.run_pip("install onnx", "Installing onnx...")
+    launch.run_pip("install onnx", "onnx...")
 
 if not launch.is_installed("onnxruntime-gpu"):
-    launch.run_pip("install onnxruntime-gpu", "Installing onnxruntime-gpu...")
+    launch.run_pip("install onnxruntime-gpu", "onnxruntime-gpu...")
 
 if not launch.is_installed("opencv-python"):
-    launch.run_pip("install opencv-python", "Installing opencv-python...")
+    launch.run_pip("install opencv-python", "opencv-python...")
 
 if not launch.is_installed("numpy"):
-    launch.run_pip("install numpy", "Installing numpy...")
+    launch.run_pip("install numpy", "numpy...")
 
 if not launch.is_installed("Pillow"):
-    launch.run_pip("install Pillow", "Installing Pillow...")
+    launch.run_pip("install Pillow", "Pillow...")
 
 if not launch.is_installed("segmentation-refinement"):
-    launch.run_pip("install segmentation-refinement", "Installing segmentation-refinement...")
+    launch.run_pip("install segmentation-refinement", "segmentation-refinement...")
 
 if not launch.is_installed("scikit-learn"):
-    launch.run_pip("install scikit-learn", "Installing scikit-learn...")
+    launch.run_pip("install scikit-learn", "scikit-learn...")
 
 if not launch.is_installed("clip"):
-    launch.run_pip("install clip", "Installing clip...")
+    launch.run_pip("install clip", "clip...")
 
 if not launch.is_installed("segment_anything"):
-    launch.run_pip("install git+https://github.com/facebookresearch/segment-anything.git", "Installing segment_anything...")
+    launch.run_pip("install git+https://github.com/facebookresearch/segment-anything.git", "segment_anything...")
+
+if not launch.is_installed("nptyping"):
+    launch.run_pip("install nptyping", "nptyping...")
+
+if sys.version_info < (3, 9):
+    # Native in 3.9 and above.
+    if not launch.is_installed("typing_extensions"):
+        launch.run_pip("install typing_extensions", "typing_extensions...")

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -9,28 +9,152 @@ import gradio as gr
 import modules.scripts as scripts
 from modules import script_callbacks
 
-from scripts.td_abg import get_foreground
+from scripts.sa_mask import segment_anything_now, do_clip, masked_images_to_pil, masks_to_pil
+from scripts.td_abg import segment_anime, td_abg, cascadePSP
 from scripts.convertor import pil2cv
 try:
     from modules.paths_internal import extensions_dir
 except Exception:
     from modules.extensions import extensions_dir
 
-from collections import OrderedDict
+from collections import namedtuple, OrderedDict
+import logging
+
+from typing import Dict, Any, NamedTuple, Union, Set, TypeVar, Tuple, List, Sequence
+try:
+    from typing import TypeGuard
+except ImportError:
+    from typing_extensions import TypeGuard
+from nptyping import NDArray, Shape, UInt8
+
+import PIL
+
+logger = logging.getLogger(__name__)
 
 
-model_cache = OrderedDict()
+model_cache: OrderedDict = OrderedDict()
 sam_model_dir = os.path.join(
     extensions_dir, "PBRemTools/models/")
 model_list = [f for f in os.listdir(sam_model_dir) if os.path.isfile(
     os.path.join(sam_model_dir, f)) and f.split('.')[-1] != 'txt']
 
+SANSettings = NamedTuple("SANSettings", (
+                         ("model_name", Union[gr.Image, PIL.Image.Image]),
+                         ("predicted_iou_threshold", Union[gr.Slider, float]),
+                         ("stability_score_threshold", Union[gr.Slider, float])))
+AnimeSegSettings = NamedTuple("AnimeSegSettings", ())
 
-def processing(input_image, td_abg_enabled, h_split, v_split, n_cluster, alpha, th_rate, cascadePSP_enabled, fast, psp_L, sa_enabled, seg_query, model_name, predicted_iou_threshold, stability_score_threshold, clip_threshold):
-    image = pil2cv(input_image)
+SegmentationSettings = NamedTuple("SegmentationSettings", (
+                                 ("tab", Union[gr.State, int]),
+                                 ("san", SANSettings),
+                                 ("anime_seg", AnimeSegSettings)))
+
+CLIPSettings = NamedTuple("CLIPSettings", (
+                          ("enabled", Union[gr.Checkbox, bool]),
+                          ("seg_query", Union[gr.Textbox, str]),
+                          ("clip_threshold", Union[gr.Slider, float])))
+
+TdAbgSettings = NamedTuple("TdAbgSettings", (
+                          ("h_split", Union[gr.Slider, int]),
+                          ("v_split", Union[gr.Slider, int]),
+                          ("n_cluster", Union[gr.Slider, int]),
+                          ("alpha", Union[gr.Slider, float]),
+                          ("th_rate", Union[gr.Slider, float])))
+
+CascadePSPSettings = NamedTuple("CascadePSPSettings", (
+                               ("extended_res", Union[gr.Checkbox, bool]),
+                               ("resolution", Union[gr.Slider, int])))
+PostprocessorSettings = NamedTuple("PostprocessorSettings", (
+                                  ("accordion", Union[gr.Accordion, bool]),
+                                  ("tab", Union[gr.State, int]),
+                                  ("move_up", Union[gr.Button, bool]),
+                                  ("move_down", Union[gr.Button, bool]),
+                                  ("clone_above", Union[gr.Button, bool]),
+                                  ("delete", Union[gr.Button, bool]),
+                                  ("td_abg", TdAbgSettings),
+                                  ("cascadePSP", CascadePSPSettings)))
+
+PostprocessingSettings = NamedTuple("PostprocessingSettings", (
+                                   ("append", Union[gr.Button, bool]),
+                                   ("num_enabled", Union[gr.State, bool]),
+                                   ("postprocessors", Tuple[PostprocessorSettings])))
+
+TopSettings = NamedTuple("TopSettings", (
+                        ("input_image", Union[gr.Image, bool]),
+                        ("segmentation", SegmentationSettings),
+                        ("clip", CLIPSettings),
+                        ("postprocessing", PostprocessingSettings),
+                        ("submit", Union[gr.Button, bool])))
+
+ImageData = namedtuple("ImageData", ("image", "masks"))
+
+FlatArgs = Dict[gr.blocks.Block, Any]
+T = TypeVar("T")
+U = TypeVar("U")
+K = TypeVar("K")
+L = TypeVar("L")
+V = TypeVar("V")
+W = TypeVar("W")
+
+
+def processing(flatargs: FlatArgs, *, top: TopSettings) -> List[PIL.Image.Image]:
+    vals = unflatten_args(flatargs=flatargs, top=top)
+    print(f"processing(flatargs={flatargs}, top={top}, vals={vals})")
+
+    if vals is None:
+        raise ValueError(f"Invalid vals flatargs={flatargs} top={top}")
+
+    image = pil2cv(vals.input_image)
     image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-    mask, image = get_foreground(image, td_abg_enabled, h_split, v_split, n_cluster, alpha, th_rate, cascadePSP_enabled, fast, psp_L, sa_enabled, seg_query, model_name, predicted_iou_threshold, stability_score_threshold, clip_threshold)
-    return image, mask
+
+    seg = vals.segmentation
+    print(f"seg.tab={seg.tab}")
+    if seg.tab == "san":
+        san = seg.san
+        
+        masks = segment_anything_now(image=image,
+            model_name=san.model_name,
+            min_predicted_iou=san.predicted_iou_threshold,
+            min_stability_score=san.stability_score_threshold)
+        image = ImageData(image=image, masks=tuple(masks))
+    elif seg.tab == "anime_seg":
+        anime_seg = seg.anime_seg
+        masks = segment_anime(image=image)
+        image = ImageData(image=image, masks=tuple(masks))
+    #elif seg == "upload_mask":
+    #   # TODO: upload mask
+    else:
+        raise ValueError(f"Invalid segmentation tab {seg.tab}")
+
+    if vals.clip.enabled:
+        clip = vals.clip
+        masks = do_clip(image=image.image,
+                        masks=masks,
+                        seg_query=clip.seg_query,
+                        clip_threshold=clip.clip_threshold)
+        image = image._replace(masks=masks)
+
+    for p in vals.postprocessing.postprocessors[:vals.postprocessing.num_enabled]:
+        if p.tab == "td_abg":
+            t = p.td_abg
+            image = image._replace(masks=tuple(td_abg(image=image.image,
+                                                      masks=image.masks,
+                                                      h_split=t.h_split,
+                                                      v_split=t.v_split,
+                                                      n_cluster=t.n_cluster,
+                                                      alpha=t.alpha,
+                                                      th_rate=t.th_rate)))
+        elif p.tab == "cascadePSP":
+            c = p.cascadePSP
+            image = image._replace(masks=tuple(cascadePSP(image=image.image,
+                                                          masks=image.masks,
+                                                          extended_res=c.extended_res,
+                                                          resolution=c.resolution)))
+        else:
+            raise ValueError(f"Invalid postprocessing tab {p.tab}")
+
+    return masked_images_to_pil(image.image, image.masks) + masks_to_pil(image.masks)
+
 
 class Script(scripts.Script):
   def __init__(self) -> None:
@@ -45,44 +169,328 @@ class Script(scripts.Script):
   def ui(self, is_img2img):
     return ()
 
+
+
+"""
+    d[k] = v, but with assertion that key is not in dict
+"""
+def add_new(d, k, v):
+    assert k not in d, f"Duplicate key {k} - was {d[k]} adding {v}"
+    d[k] = v
+    return d
+
+"""
+    return {**a, **b}, but with assertion that keys do not overlap
+"""
+def merged_dicts(a: Dict[K, V], b: Dict[L, W]) -> Dict[Union[K, L], Union[V, W]]:
+    t: Dict[Union[K, L], Union[V, W]] = {k: v for k, v in a.items()}
+    for k,v in b.items():
+        add_new(t, k, v)
+    return t
+"""
+    return a | b, but with assertion that keys do not overlap
+"""
+def merged_sets(a: Set[T], b: Set[U]) -> Set[Union[T, U]]:
+    ret = a | b
+    assert len(ret) == len(a) + len(b), f"Duplicate key(s) {a.union(b)}"
+    return ret
+
+
+def is_any_named_tuple(o: Any) -> TypeGuard[NamedTuple]:
+    return isinstance(o, tuple) and hasattr(o, "_asdict") and hasattr(o, "_fields")
+
+
+"""
+    Turns a potentially-nested namedtuple of components into a flat set.
+"""
+def get_components(c: Any, sofar: Union[Set[gr.components.Component], None]=None) -> Set[gr.components.Component]:
+    if sofar is None:
+        sofar = set()
+    if is_any_named_tuple(c):
+        for v in c._asdict().values():
+            get_components(v, sofar)
+    elif isinstance(c, list) or isinstance(c, tuple):
+        for v in c:
+            get_components(v, sofar)
+    elif isinstance(c, gr.components.Component):
+        assert c not in sofar, f"Duplicate component {c}"
+        sofar.add(c)
+    elif isinstance(c, gr.blocks.Block):
+        pass
+    else:
+        logger.warn(f"Unknown component {c} of type {type(c)}")
+    return sofar
+
+
+"""
+    top: a potentially-nested namedtuple of components
+    flatargs: a dictionary from components to values
+
+    output: a potentially-nested namedtuple of values
+"""
+def unflatten_args(flatargs: FlatArgs, top: T) -> Union[T, None]:
+    if is_any_named_tuple(top):
+        return top._replace(**{k: unflatten_args(flatargs, v) for k, v in top._asdict().items()}) # type: ignore
+    elif isinstance(top, list) or isinstance(top, tuple):
+        nxt = [unflatten_args(flatargs, v) for v in top]
+        if isinstance(top, tuple):
+            return tuple(nxt) # type: ignore
+        return nxt # type: ignore
+    elif isinstance(top, gr.components.Component):
+        return flatargs[top]
+    elif isinstance(top, gr.blocks.Block):
+        return None
+    else:
+        logger.warn(f"Unknown component {top} of type {type(top)}")
+        return None
+
+"""
+    Moves the values in 'a' to 'b' instead
+"""
+def nested_move(a: Any, b: Any, args: FlatArgs, sofar:Union[Dict[gr.blocks.Block, Any], None]=None) -> Dict[gr.blocks.Block, Any]:
+    if sofar is None:
+        sofar = {}
+    assert type(a) == type(b), f"Cannot swap {a} and {b} ({type(a)} != {type(b)})"
+    if is_any_named_tuple(a):
+        for aa, bb in zip(a._asdict().items(), b._asdict().items()):
+            ak, av = aa
+            bk, bv = bb
+            assert ak == bk, f"Key mismatch: {aa} != {bb}"
+            nested_move(av, bv, args, sofar)
+    elif isinstance(a, list) or isinstance(a, tuple):
+        for av, bv in zip(a, b):
+            nested_move(av, bv, args, sofar)
+    elif isinstance(a, gr.components.Component):
+        add_new(sofar, b, args[a])
+    elif isinstance(a, gr.blocks.Block):
+        pass
+    else:
+        logger.warn(f"Unknown component {a} of type {type(a)}")
+    return sofar
+
+
+def update_buttons(ret: Dict[gr.blocks.Block, Any], postprocessing: PostprocessingSettings, num_enabled: int) -> Dict[gr.blocks.Block, Any]:
+    print(f"update_buttons(ret={ret}, postprocessing={postprocessing})")
+    # TODO: more efficient update
+    for i, p in enumerate(postprocessing.postprocessors):
+        ret[p.move_up] = gr.update(interactive=(i > 0))
+        ret[p.move_down] = gr.update(interactive=(i < num_enabled-1))
+        ret[p.clone_above] = gr.update(interactive=num_enabled < len(postprocessing.postprocessors))
+    add_new(ret, postprocessing.append, gr.update(interactive=num_enabled < len(postprocessing.postprocessors)))
+    print(f"update_buttons(ret={ret}, postprocessing={postprocessing}) -> {ret}")
+    return ret
+
+
+def swap_postprocessors(a: Any, b: Any, args: FlatArgs, postprocessing: PostprocessingSettings) -> Dict[gr.blocks.Block, Any]:
+    print(f"swap_postprocessors(a={a}, b={b}, args={args}, postprocessing={postprocessing})")
+    num_enabled = args[postprocessing.num_enabled]
+    if a >= num_enabled:
+        logger.warn(f"Cannot swap postprocessor {a} past end {num_enabled}")
+        return args
+    if b >= num_enabled:
+        logger.warn(f"Cannot swap postprocessor {b} past end {num_enabled}")
+        return args
+    pa, pb = postprocessing.postprocessors[a], postprocessing.postprocessors[b]
+    qa, qb = nested_move(pa, pb, args), nested_move(pb, pa, args)
+    ret = merged_dicts(qa, qb)
+
+    update_buttons(ret, postprocessing, num_enabled)
+
+    print(f"swap_postprocessors(a={a}, b={b}, args={args}, postprocessing={postprocessing}) -> {ret}")
+
+    return ret
+
+def insert_postprocessor(index: int, args: FlatArgs, postprocessing: PostprocessingSettings) -> Dict[gr.blocks.Block, Any]:
+    num_enabled = postprocessing.num_enabled
+    if args[num_enabled] >= len(postprocessing.postprocessors):
+        logger.warn("Cannot insert postprocessor; all slots full")
+        return args
+    
+    ret: Dict[gr.blocks.Block, Any] = {}
+    for i in range(index+1, len(postprocessing.postprocessors)):
+        nested_move(postprocessing.postprocessors[i-1], postprocessing.postprocessors[i], args, ret)
+
+    # TODO: reset values to defaults
+    # You'd think there'd be a method for this...
+
+    add_new(ret, num_enabled, args[num_enabled] + 1)
+
+    for i, p in enumerate(postprocessing.postprocessors):
+        add_new(ret, p.accordion, gr.update(visible=(i < ret[num_enabled])))
+
+    update_buttons(ret, postprocessing, ret[num_enabled])
+
+    return ret
+
+def append_postprocessor(args: FlatArgs, postprocessing: PostprocessingSettings) -> Dict[gr.blocks.Block, Any]:
+    num_enabled = args[postprocessing.num_enabled]
+    return insert_postprocessor(num_enabled, args, postprocessing)
+
+
+def delete_postprocessor(index: int, args: FlatArgs, postprocessing: PostprocessingSettings) -> Dict[gr.blocks.Block, Any]:
+    num_enabled = postprocessing.num_enabled
+    postprocessors = postprocessing.postprocessors
+    if args[num_enabled] <= 0:
+        logger.warn("Cannot delete postprocessor; all slots full")
+        return args
+    
+    ret: Dict[gr.blocks.Block, Any] = {}
+    for i in range(index+1, len(postprocessors)):
+        nested_move(postprocessing.postprocessors[i], postprocessing.postprocessors[i-1], args, ret)
+    
+    # TODO: reset values to defaults
+    # You'd think there'd be a method for this...
+    
+    add_new(ret, num_enabled, args[num_enabled] - 1)
+
+    for i, p in enumerate(postprocessors):
+        add_new(ret, p.accordion, gr.update(visible=(i < ret[num_enabled])))
+
+    update_buttons(ret, postprocessing, ret[num_enabled])
+
+    return ret
+
+
 def on_ui_tabs():
     with gr.Blocks(analytics_enabled=False) as PBRemTools:
         with gr.Row():
             with gr.Column():
                 input_image = gr.Image(type="pil")
-                with gr.Accordion("Mask Setting", open=True):
-                  with gr.Accordion("Segment Anything & CLIP", open=True):  
-                    with gr.Accordion("Segment Anything & CLIP", open=True):
-                      sa_enabled = gr.Checkbox(label="enabled", show_label=True)
-                      model_name = gr.Dropdown(label="Model", elem_id="sam_model", choices=model_list,
-                                          value=model_list[0] if len(model_list) > 0 else None)
-                      seg_query = gr.Textbox(label = "segmentation prompt", show_label=True)
-                      predicted_iou_threshold = gr.Slider(0, 1, value=0.9, step=0.01, label="predicted_iou_threshold", show_label=True)
-                      stability_score_threshold = gr.Slider(0, 1, value=0.9, step=0.01, label="stability_score_threshold", show_label=True)
-                      clip_threshold =  gr.Slider(0, 1, value=0.1, step=0.01, label="clip_threshold", show_label=True)
 
-                with gr.Accordion("Post Processing", open=True):
-                  with gr.Accordion("tile division BG Removers", open=True):
-                      td_abg_enabled = gr.Checkbox(label="enabled", show_label=True)
-                      h_split = gr.Slider(1, 2048, value=256, step=4, label="horizontal split num", show_label=True)
-                      v_split = gr.Slider(1, 2048, value=256, step=4, label="vertical split num", show_label=True)
-                      
-                      n_cluster = gr.Slider(1, 1000, value=500, step=10, label="cluster num", show_label=True)
-                      alpha = gr.Slider(1, 255, value=50, step=1, label="alpha threshold", show_label=True)
-                      th_rate = gr.Slider(0, 1, value=0.1, step=0.01, label="mask content ratio", show_label=True)
-                        
-                  with gr.Accordion("cascadePSP", open=True):
-                      cascadePSP_enabled = gr.Checkbox(label="enabled", show_label=True)
-                      fast = gr.Checkbox(label="fast", show_label=True)
-                      psp_L = gr.Slider(1, 2048, value=900, step=1, label="Memory usage", show_label=True)
+                with gr.Accordion("Segmentation", open=True):
+                    cur_tab = gr.State("san")
+                    with gr.Tabs(selected="san") as tabs:
+                        with gr.Tab("Segment Anything Now", id="san") as tab:
+                            tab.select(lambda: "san", inputs=None, outputs=[cur_tab])
+                            gr.Checkbox(label="Segment Anything Now", show_label=True, interactive=False, value=True)
+                            model_name = gr.Dropdown(label="Model", elem_id="sam_model", choices=model_list,
+                                                value=model_list[0] if len(model_list) > 0 else None)
+                            predicted_iou_threshold = gr.Slider(0, 1, value=0.9, step=0.01, label="Min Predicted IOU", show_label=True)
+                            stability_score_threshold = gr.Slider(0, 1, value=0.9, step=0.01, label="Min Stability Score", show_label=True)
+                            san = SANSettings(model_name=model_name,
+                                              predicted_iou_threshold=predicted_iou_threshold,
+                                              stability_score_threshold=stability_score_threshold)
+                        with gr.Tab("Anime Segmentation", id="anime_seg") as tab:
+                            tab.select(lambda: "anime_seg", inputs=None, outputs=[cur_tab])
+                            gr.Checkbox(label="Anime Segmentation", show_label=True, interactive=False, value=True)
+                            anime_seg = AnimeSegSettings()
+                        #with gr.Tab("Upload Mask") as tab:
+                        #    san.select(lambda: "upload_mask", inputs=None, outputs=cur_tab)
+                        #    upload_mask = UploadMaskSettings()
+                    
+                    segmentation = SegmentationSettings(tab=cur_tab, san=san, anime_seg=anime_seg#, upload_mask=upload_mask
+                        )
 
+                
+                with gr.Accordion("CLIP", open=True):
+                    enabled = gr.Checkbox(label="Enabled", show_label=True)
+                    seg_query = gr.Textbox(label = "Prompt", show_label=True)
+                    clip_threshold =  gr.Slider(0, 1, value=0.1, step=0.01, label="Clip Threshold", show_label=True)
+                    clip = CLIPSettings(enabled=enabled,
+                        seg_query=seg_query,
+                        clip_threshold=clip_threshold)
+
+                with gr.Accordion("Postprocessing", open=True):
+                    MAX_POSTPROCESSORS = 2
+
+                    postprocessors = []
+                    accordions = set()
+                    for i in range(MAX_POSTPROCESSORS):
+                        with gr.Accordion(f"Postprocessor {i}", open=True, visible=False) as accordion:
+                            accordions.add(accordion)
+                            with gr.Row():
+                                move_up = gr.Button(value="Move Up", interactive=(i > 0))
+                                move_down = gr.Button(value="Move Down", interactive=False)
+                                clone_above = gr.Button(value="Clone Above")
+                                delete = gr.Button(value="Delete")
+
+                            cur_tab = gr.State("cascadePSP")
+                            with gr.Tabs(selected="cascadePSP") as tabs:
+                                with gr.Tab("Tile Division ABG", id="td_abg") as tab:
+                                    tab.select(lambda: "td_abg", inputs=None, outputs=[cur_tab])
+                                    h_split = gr.Slider(1, 2048, value=256, step=4, label="# of Horizontal Splits", show_label=True)
+                                    v_split = gr.Slider(1, 2048, value=256, step=4, label="# of Vertical Splits", show_label=True)
+                                    
+                                    n_cluster = gr.Slider(1, 1000, value=500, step=10, label="# of Clusters", show_label=True)
+                                    alpha = gr.Slider(1, 255, value=100, step=1, label="Alpha Threshold", show_label=True)
+                                    th_rate = gr.Slider(0, 1, value=0.1, step=0.01, label="Mask Content Ratio", show_label=True)
+
+                                    td_abg = TdAbgSettings(h_split=h_split,
+                                                           v_split=v_split,
+                                                           n_cluster=n_cluster,
+                                                           alpha=alpha,
+                                                           th_rate=th_rate)
+
+                                with gr.Tab("cascadePSP", id="cascadePSP") as tab:
+                                    tab.select(lambda: "cascadePSP", inputs=None, outputs=[cur_tab])
+                                    extended_res = gr.Checkbox(label="Extended Resolution", show_label=True)
+                                    resolution = gr.Slider(1, 2048, value=900, step=1, label="Resolution", show_label=True)
+
+                                    cascadePSP = CascadePSPSettings(extended_res=extended_res, resolution=resolution)
+
+                            postprocessors.append(PostprocessorSettings(tab=cur_tab,
+                                                                        accordion=accordion,
+                                                                        move_up=move_up,
+                                                                        move_down=move_down,
+                                                                        clone_above=clone_above,
+                                                                        delete=delete,
+                                                                        td_abg=td_abg,
+                                                                        cascadePSP=cascadePSP))
+
+                    num_enabled = gr.State(0)
+                    append = gr.Button(value="Append New Postprocessor")
+
+                    postprocessors = tuple(postprocessors) # freeze list into tuple now that we're done constructing
+
+
+                    postprocessing = PostprocessingSettings(append=append, num_enabled=num_enabled, postprocessors=postprocessors)
+                    # The below is all very inefficient, but meh.
+                    args = get_components(postprocessing)
+                    oargs = merged_sets(args, accordions)
+                    for i in range(1, MAX_POSTPROCESSORS):
+                        postprocessors[i].move_up.click(
+                            lambda args, i=i, postprocessing=postprocessing: swap_postprocessors(i-1, i, args, postprocessing),
+                            inputs=args,
+                            outputs=args
+                        )
+                        postprocessors[i-1].move_down.click(
+                            lambda args, i=i, postprocessing=postprocessing: swap_postprocessors(i-1, i, args, postprocessing),
+                            inputs=args,
+                            outputs=args
+                        )
+                    for i in range(MAX_POSTPROCESSORS):
+                        postprocessors[i].delete.click(
+                            fn = (lambda args, i=i, postprocessing=postprocessing: delete_postprocessor(i, args, postprocessing)),
+                            inputs = args,
+                            outputs = oargs
+                        )
+                        postprocessors[i].clone_above.click(
+                            fn = (lambda args, i=i, postprocessing=postprocessing: insert_postprocessor(i, args, postprocessing)),
+                            inputs = args,
+                            outputs = oargs
+                        )
+                    append.click(
+                        fn = (lambda args, postprocessing=postprocessing: append_postprocessor(args, postprocessing)),
+                        inputs = args,
+                        outputs = oargs
+                    )
                 submit = gr.Button(value="Submit")
             with gr.Row():
                 with gr.Column():
                     gallery = gr.Gallery(label="outputs", show_label=True, elem_id="gallery").style(grid=2)
+
+        top = TopSettings(input_image=input_image,
+                          segmentation=segmentation,
+                          clip=clip,
+                          postprocessing=postprocessing,
+                          submit=submit)
+        
+        all_inputs = get_components(top)
+
         submit.click(
-            processing, 
-            inputs=[input_image, td_abg_enabled, h_split, v_split, n_cluster, alpha, th_rate, cascadePSP_enabled, fast, psp_L, sa_enabled, seg_query, model_name, predicted_iou_threshold, stability_score_threshold, clip_threshold], 
+            # Python argument capture is a little weird, hence the default-argument dance.
+            fn = (lambda args, top=top: processing(args, top=top)), 
+            inputs=all_inputs,
             outputs=gallery
         )
 

--- a/scripts/sa_mask.py
+++ b/scripts/sa_mask.py
@@ -2,7 +2,7 @@ import os
 import urllib
 from functools import lru_cache
 from random import randint
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict, List, Tuple, TypeVar
 
 import clip
 import cv2
@@ -11,7 +11,9 @@ import numpy as np
 import PIL
 import torch
 from segment_anything import SamAutomaticMaskGenerator, sam_model_registry
+from segment_anything.modeling import Sam
 from collections import OrderedDict
+from nptyping import NDArray, Shape, UInt8, Float32
 
 try:
     from modules.paths_internal import extensions_dir
@@ -21,7 +23,9 @@ except Exception:
 from modules.safe import unsafe_torch_load, load
 from modules.devices import device
 
-model_cache = OrderedDict()
+from scripts.convertor import cv2pil
+
+model_cache: OrderedDict = OrderedDict()
 sam_model_dir = os.path.join(
     extensions_dir, "PBRemTools/models/")
 model_list = [f for f in os.listdir(sam_model_dir) if os.path.isfile(
@@ -32,7 +36,7 @@ CLIP_WIDTH = CLIP_HEIGHT = 300
 THRESHOLD = 0.05
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-def load_sam_model(sam_checkpoint):
+def load_sam_model(sam_checkpoint: str) -> Sam:
     model_type = '_'.join(sam_checkpoint.split('_')[1:-1])
     sam_checkpoint = os.path.join(sam_model_dir, sam_checkpoint)
     torch.load = unsafe_torch_load
@@ -42,11 +46,12 @@ def load_sam_model(sam_checkpoint):
     return sam
 
 
-def load_mask_generator(model_name) -> SamAutomaticMaskGenerator:
+def load_mask_generator(model_name: str) -> SamAutomaticMaskGenerator:
     sam = load_sam_model(model_name)
     mask_generator = SamAutomaticMaskGenerator(sam)
     torch.load = load
     return mask_generator
+
 
 def load_clip(
     name: str = "ViT-B/32",
@@ -54,8 +59,8 @@ def load_clip(
     model, preprocess = clip.load(name, device=device)
     return model.to(device), preprocess
 
-
-def adjust_image_size(image: np.ndarray) -> np.ndarray:
+# Any->Any isn't correct, but see https://github.com/ramonhagenaars/nptyping/issues/107
+def adjust_image_size(image: NDArray[Shape["Height,Width,..."], Any]) -> NDArray[Shape["*,*,..."], Any]:
     height, width = image.shape[:2]
     if height > width:
         if height > MAX_HEIGHT:
@@ -81,90 +86,110 @@ def get_scores(crops: List[PIL.Image.Image], query: str) -> torch.Tensor:
     return probs[:, 0].softmax(dim=0)
 
 
-def filter_masks(
-    image: np.ndarray,
-    masks: List[Dict[str, Any]],
-    predicted_iou_threshold: float,
-    stability_score_threshold: float,
-    query: str,
+def bbox(image: NDArray[Shape["Height,Width,..."], Any]) -> Tuple[int, int, int, int]:
+    rows = np.any(image, axis=0)
+    cols = np.any(image, axis=1)
+    ymin, ymax = np.where(rows)[0][[0, -1]]
+    xmin, xmax = np.where(cols)[0][[0, -1]]
+
+    return xmin, xmax, ymin, ymax
+
+
+def union_masks(image: NDArray[Shape["Height,Width, [r,g,b]"], UInt8], masks: List[NDArray[Shape["Height,Width"], UInt8]]) -> NDArray[Shape["Height,Width,[r,g,b]"], UInt8]:
+    union_mask = np.zeros(image.shape[:-1], dtype=np.uint8)
+    for mask in masks:
+        union_mask = np.maximum(union_mask, mask)
+    return union_mask
+
+
+def do_clip(
+    image: NDArray[Shape["Height,Width,[r,g,b]"], UInt8],
+    masks: List[NDArray[Shape["Height,Width"], UInt8]],
+    seg_query: str,
     clip_threshold: float,
-) -> List[Dict[str, Any]]:
+) -> List[NDArray[Shape["Height,Width"], UInt8]]:
     cropped_masks: List[PIL.Image.Image] = []
-    filtered_masks: List[Dict[str, Any]] = []
 
     for mask in masks:
-        if (
-            mask["predicted_iou"] < predicted_iou_threshold
-            or mask["stability_score"] < stability_score_threshold
-        ):
-            continue
-
-        filtered_masks.append(mask)
-
-        x, y, w, h = mask["bbox"]
-        crop = image[y : y + h, x : x + w]
-        crop = cv2.cvtColor(crop, cv2.COLOR_BGR2RGB)
-        crop = PIL.Image.fromarray(np.uint8(crop * 255)).convert("RGB")
+        xmin, xmax, ymin, ymax = bbox(mask)
+        print("do_clip", image, image.shape, image.dtype, mask, mask.shape, mask.dtype, xmin, xmax, ymin, ymax)
+        crop = image[ymin:ymax, xmin:xmax]
+        crop = PIL.Image.fromarray(crop, mode="RGB")
         crop.resize((CLIP_WIDTH, CLIP_HEIGHT))
         cropped_masks.append(crop)
 
-    if query and filtered_masks:
-        scores = get_scores(cropped_masks, query)
-        filtered_masks = [
-            filtered_masks[i]
-            for i, score in enumerate(scores)
-            if score > clip_threshold
-        ]
+    scores = get_scores(cropped_masks, seg_query)
+    print(scores)
+    masks = [
+        masks[i]
+        for i, score in enumerate(scores)
+        if score >= clip_threshold
+    ]
 
-    return filtered_masks
+    masks = [union_masks(image, masks)]
 
-
-def draw_masks(image, masks, alpha: float = 0.7) -> np.ndarray:
-    for mask in masks:
-        color = [randint(127, 255) for _ in range(3)]
-
-        # draw mask overlay
-        colored_mask = np.expand_dims(mask["segmentation"], 0).repeat(3, axis=0)
-        colored_mask = np.moveaxis(colored_mask, 0, -1)
-        masked = np.ma.MaskedArray(image, mask=colored_mask, fill_value=color)
-        image_overlay = masked.filled()
-        image = cv2.addWeighted(image, 1 - alpha, image_overlay, alpha, 0)
-
-        # draw contour
-        contours, _ = cv2.findContours(
-            np.uint8(mask["segmentation"]), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
-        )
-        cv2.drawContours(image, contours, -1, (255, 0, 0), 2)
-    return image
-
-
-def segment(predicted_iou_threshold, stability_score_threshold, clip_threshold, image, query, model_name):
-    mask_generator = load_mask_generator(model_name)
-    image = adjust_image_size(image)
-    masks = mask_generator.generate(image)
-    masks = filter_masks(
-        image,
-        masks,
-        predicted_iou_threshold,
-        stability_score_threshold,
-        query,
-        clip_threshold,
-    )
-    image = draw_masks(image, masks)
-    image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
-    image = PIL.Image.fromarray(np.uint8(image)).convert("RGB")
     return masks
 
 
-def get_sa_mask(image, query, model_name, predicted_iou_threshold, stability_score_threshold, clip_threshold):
-    masks = segment(predicted_iou_threshold, stability_score_threshold, clip_threshold, image, query, model_name)
+def masked_images_to_pil(
+    image: NDArray[Shape["Height,Width,[r,g,b]"], UInt8],
+    masks: List[NDArray[Shape["Height,Width"], UInt8]],
+) -> List[PIL.Image.Image]:
+    ret = []
+    for mask in masks:
+        print("masked_images_to_pil", image, image.shape, image.dtype, mask, mask.shape, mask.dtype)
+        s = list(image.shape)
+        s[-1] = 4
+        nimage = np.empty(s, dtype=image.dtype)
+        nimage[:,:,:3] = image
+        nimage[:,:,3] = mask
+
+        ret.append(PIL.Image.fromarray(nimage, mode="RGBA"))
+    return ret
+
+
+def masks_to_pil(
+        masks: List[NDArray[Shape["Height,Width"], UInt8]]) -> List[PIL.Image.Image]:
+    ret = []
+    for mask in masks:
+        print("masks_to_pil", mask, mask.shape, mask.dtype)
+        ret.append(PIL.Image.fromarray(mask, mode="L").convert("RGB"))
+    return ret
+
+
+#def draw_masks(image: np.ndarray, masks: Tuple[np.ndarray], alpha: float = 0.7) -> np.ndarray:
+#    for mask in masks:
+#        color = [randint(127, 255) for _ in range(3)]
+#
+#        # draw mask overlay
+#        colored_mask = np.expand_dims(mask["segmentation"], 0).repeat(3, axis=0)
+#        colored_mask = np.moveaxis(colored_mask, 0, -1)
+#        masked: np.ma.MaskedArray = np.ma.MaskedArray(image, mask=colored_mask, fill_value=color)
+#        image_overlay = masked.filled()
+#        image = cv2.addWeighted(image, 1 - alpha, image_overlay, alpha, 0)
+#
+#        # draw contour
+#        contours, _ = cv2.findContours(
+#            np.uint8(mask["segmentation"]), cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+#        )
+#        cv2.drawContours(image, contours, -1, (255, 0, 0), 2)
+#    return image
+
+
+def segment_anything_now(image: NDArray[Shape["Height,Width, [r,g,b]"], UInt8],
+                         model_name: str, min_predicted_iou: float, min_stability_score: float) -> List[NDArray[Shape["Height,Width"], UInt8]]:
+    mask_generator = load_mask_generator(model_name)
+    image = adjust_image_size(image)
+    masks = mask_generator.generate(image)
     mask_list = []
     for mask in masks:
-        colored_mask = np.expand_dims(mask["segmentation"], 0).repeat(3, axis=0)
-        colored_mask = np.moveaxis(colored_mask, 0, -1)
-        colored_mask = np.where(colored_mask, 0, 255)
+        if (
+            mask["predicted_iou"] < min_predicted_iou
+            or mask["stability_score"] < min_stability_score
+        ):
+            continue
+        colored_mask = mask["segmentation"].astype(np.uint8) * 255
+        print("segment_anything_now", colored_mask, colored_mask.shape, colored_mask.dtype)
         mask_list.append(colored_mask)
-    combined_mask = np.minimum.reduce(mask_list)
+    return mask_list
 
-    return 255 - combined_mask
-    

--- a/scripts/td_abg.py
+++ b/scripts/td_abg.py
@@ -1,4 +1,3 @@
-import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -27,7 +26,7 @@ import numpy as np
 import PIL
 import torch
 from segment_anything import SamAutomaticMaskGenerator, sam_model_registry
-from scripts.sa_mask import  get_sa_mask
+from nptyping import NDArray, Shape, UInt8
 
 
 # Declare Execution Providers
@@ -38,16 +37,12 @@ model_path = huggingface_hub.hf_hub_download(
     "skytnt/anime-seg", "isnetis.onnx")
 rmbg_model = rt.InferenceSession(model_path, providers=providers)
 
-def get_mask(img, s=1024):
-    img = (img / 255).astype(np.float32)
-    dim = img.shape[2]
-    if dim == 4:
-        img = img[..., :3]
-        dim = 3
+def segment_anime(image: NDArray[Shape["Height,Width,[r,g,b]"], UInt8], s:int=1024) -> List[NDArray[Shape["Height,Width"], UInt8]]:
+    img = (image / 255.).astype(np.float32)
     h, w = h0, w0 = img.shape[:-1]
     h, w = (s, int(s * w / h)) if h > w else (int(s * h / w), s)
     ph, pw = s - h, s - w
-    img_input = np.zeros([s, s, dim], dtype=np.float32)
+    img_input = np.zeros([s, s, 3], dtype=np.float32)
     img_input[ph // 2:ph // 2 + h, pw //
               2:pw // 2 + w] = cv2.resize(img, (w, h))
     img_input = np.transpose(img_input, (2, 0, 1))
@@ -55,61 +50,41 @@ def get_mask(img, s=1024):
     mask = rmbg_model.run(None, {'img': img_input})[0][0]
     mask = np.transpose(mask, (1, 2, 0))
     mask = mask[ph // 2:ph // 2 + h, pw // 2:pw // 2 + w]
-    mask = cv2.resize(mask, (w0, h0))[:, :, np.newaxis]
-    return mask
+    mask = cv2.resize(mask, (w0, h0))
 
-def assign_tile(row, tile_width, tile_height):
+    # Convert back to uint8
+    mask = np.clip(mask, 0, 1) * 255
+    mask = np.rint(mask).astype(np.uint8)
+    return [mask]
+
+def assign_tile(row: pd.DataFrame, tile_width: int, tile_height:int) -> str:
     tile_x = row['x_l'] // tile_width
     tile_y = row['y_l'] // tile_height
     return f"tile_{tile_y}_{tile_x}"
 
-def rmbg_fn(img):
-    mask = get_mask(img)
-    img = (mask * img + 255 * (1 - mask)).astype(np.uint8)
-    mask = (mask * 255).astype(np.uint8)
-    img = np.concatenate([img, mask], axis=2, dtype=np.uint8)
-    mask = mask.repeat(3, axis=2)
-    return mask, img
+def cascadePSP(image: NDArray[Shape["Height,Width,[r,g,b]"], UInt8],
+               masks: List[NDArray[Shape["Height,Width"], UInt8]],
+               extended_res: bool, resolution: int) -> List[NDArray[Shape["Height,Width"], UInt8]]:
+    refiner = refine.Refiner(device='cuda:0') # device can also be cpu'
+    masks_out = []
+    for mask in masks:
+        # Fast - Global step only.
+        # Smaller L -> Less memory usage; faster in fast mode.
+        mask_out = refiner.refine(image, mask, fast=not extended_res, L=resolution)
 
-def refinement(img, mask, fast, psp_L):
-    mask =  cv2.cvtColor(mask, cv2.COLOR_RGB2GRAY)
-    refiner = refine.Refiner(device='cuda:0') # device can also be 'cpu'
-
-    # Fast - Global step only.
-    # Smaller L -> Less memory usage; faster in fast mode.
-    mask = refiner.refine(img, mask, fast=fast, L=psp_L) 
-
+        masks_out.append(mask_out)
     with torch.no_grad():
         torch.cuda.empty_cache()
+    return masks_out
 
-    return mask
-
-
-
-def get_foreground(img, td_abg_enabled, h_split, v_split, n_cluster, alpha, th_rate, cascadePSP_enabled, fast, psp_L, sa_enabled ,query, model_name, predicted_iou_threshold, stability_score_threshold, clip_threshold):
-    df = rgb2df(img)
-    image_width = img.shape[1] 
-    image_height = img.shape[0] 
-    if td_abg_enabled == True:
-        if cascadePSP_enabled == True:
-            if sa_enabled == True:     
-                mask = get_sa_mask(img, query, model_name, predicted_iou_threshold, stability_score_threshold, clip_threshold)
-                mask = cv2.resize(np.uint8(mask),(image_width,image_height))
-                print(mask.shape)
-            else:
-                mask = get_mask(img)
-            mask =  refinement(img, mask, fast, psp_L)
-            mask = cv2.cvtColor(mask, cv2.COLOR_GRAY2RGB)
-
-        else:
-            if sa_enabled == True:     
-                mask = get_sa_mask(img, query, model_name, predicted_iou_threshold, stability_score_threshold, clip_threshold)
-                mask = cv2.resize(np.uint8(mask),(image_width,image_height))
-            else:    
-                mask = get_mask(img)
-                mask = (mask * 255).astype(np.uint8)
-                mask = mask.repeat(3, axis=2)
-
+def td_abg(image: NDArray[Shape["Height,Width,[r,g,b]"], UInt8],
+           masks: List[NDArray[Shape["Height,Width"], UInt8]],
+           h_split: int, v_split: int, n_cluster: int, alpha: float, th_rate: float) -> List[NDArray[Shape["Height,Width"], UInt8]]:
+    masks_out = []
+    image_width = image.shape[1] 
+    image_height = image.shape[0] 
+    for mask in masks:
+        df = rgb2df(image)
         num_horizontal_splits = h_split
         num_vertical_splits = v_split
         tile_width = image_width // num_horizontal_splits
@@ -123,37 +98,22 @@ def get_foreground(img, td_abg_enabled, h_split, v_split, n_cluster, alpha, th_r
 
         mask_df = rgb2df(mask)
         mask_df['bg_label'] = (mask_df['r'] > alpha) & (mask_df['g'] > alpha) & (mask_df['b'] > alpha)
+        
 
         img_df = df.copy()
         img_df["bg_label"] = mask_df["bg_label"]
         img_df["label"] = img_df["label"].astype(str) + "-" + img_df["tile"]
         bg_rate = img_df.groupby("label").sum()["bg_label"]/img_df.groupby("label").count()["bg_label"]
         img_df['bg_cls'] = (img_df['label'].isin(bg_rate[bg_rate > th_rate].index)).astype(int)
-        img_df.loc[img_df['bg_cls'] == 0, ['a']] = 0
-        img_df.loc[img_df['bg_cls'] != 0, ['a']] = 255
-        img = df2rgba(img_df)
+        #img_df.loc[img_df['bg_cls'] == 0, ['a']] = 0
+        #img_df.loc[img_df['bg_cls'] != 0, ['a']] = 255
+        #img = df2rgba(img_df)
 
-    if cascadePSP_enabled == True and td_abg_enabled == False:
-        if sa_enabled == True:     
-            mask = get_sa_mask(img, query, model_name, predicted_iou_threshold, stability_score_threshold, clip_threshold)
-            mask = cv2.resize(np.uint8(mask),(image_width,image_height))
-            mask = cv2.cvtColor(mask, cv2.COLOR_RGB2GRAY)
-        else:
-            mask = get_mask(img)
-            mask = (mask * 255).astype(np.uint8)
-        refiner = refine.Refiner(device='cuda:0')
-        mask = refiner.refine(img, mask, fast=fast, L=psp_L)
-        with torch.no_grad():
-            torch.cuda.empty_cache()
-        img = np.dstack((img, mask))
+        mask_df.loc[img_df['bg_cls'] == 0, ['r', 'g', 'b', 'a']] = (255, 255, 255, 0)
+        mask_df.loc[img_df['bg_cls'] != 0, ['r', 'g', 'b', 'a']] = (0, 0, 0, 0)
+        mask = df2rgba(mask_df)
+        
+        masks_out.append(mask)
     
-    if cascadePSP_enabled == False and td_abg_enabled == False:
-        mask, img = rmbg_fn(img)
-
-    return mask, img
-
-
-
-
-
+    return masks_out
 


### PR DESCRIPTION
Probably rather over-engineered in some regards, and doesn't so much fix UI issues as lays the groundwork for fixing UI issues, but meh. I figured I'd get some feedback before spending too much time on this.

Basic idea is to rework this in a pipeline-esque fashion:

1. Use something to create mask(s) for the image (Segment Anything Now or anime-seg currently; easily extensible to e.g. a manual mask upload)
2. Potentially filter and combine said masks using CLIP
3. Run postprocessors on masks, in whatever order.

To the best of my knowledge this allows you to do everything the current UI does, as well as a few other currently-mainly-useless things, like running cascadePSP twice in a row.

I also cleaned up a few names to be somewhat more descriptive (in my opinion, at least :-) ), and added type hints in most places I touched. Masks are now uniformly 2d uint8 arrays, and images are uniformly 3d uint8 (RGB) arrays (except for final PIL images).

UI now looks like this:

![image](https://user-images.githubusercontent.com/120983792/234183577-f6c859d2-d71f-4638-9619-26995bb020c5.png)

I am abusing the Gradio framework somewhat. Gradio _really_ isn't designed for rearrangeable components. Ditto, I'm using 'whatever tab is currently selected' as an input, which requires a dance through a `gr.State` because a `Tabs` component doesn't have an output.

Wishlist/todos:

1. Add tooltips to everything.
2. Add manual mask upload. 
3. Disable submission button if no image is uploaded.
4. Add manual mask selection option as an alternative to CLIP.
5. Allow multiple prompts for CLIP. (E.g. sorting all inputs into whichever prompt is closest).
6. Move CLIP into generic postprocessors, to allow running CLIP after other postprocessors.
7. Add minimum/maximum # of outputs for CLIP step.

Be aware that I am running this on a cursed setup (Python 3.8; pytorch 2.1.0a0 on ROCm on a RX7900 XTX, all inside Docker (but not a true Docker image, merely a series of Docker exports and imports abused as version control) running on a Debian box with a built-from-source kernel 6.2.) It is _entirely_ possible that this Works On My Machine (TM) (and nowhere else).

I currently have this marked as draft because:

1. `demo.py` is utterly broken and needs to be fixed.
2. I don't know if different input pixel formats work. I don't know if the Gradio component always converts or not...

I'm fine with it getting merged, but marking as draft serves as a decent heads-up for the above. Both should be straightforward enough; I just ran out of time tonight and wanted to get this up.