### PR TITLE
fix duplicate install dialog and refactor

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,28 +1,19 @@
 import launch
 
-if not launch.is_installed("onnx"):
-    launch.run_pip("install onnx", "Installing onnx...")
+packages = [
+    "onnx",
+    "onnxruntime-gpu",
+    "opencv-python",
+    "numpy",
+    "Pillow",
+    "segmentation-refinement",
+    "scikit-learn",
+    "clip",
+]
 
-if not launch.is_installed("onnxruntime-gpu"):
-    launch.run_pip("install onnxruntime-gpu", "Installing onnxruntime-gpu...")
-
-if not launch.is_installed("opencv-python"):
-    launch.run_pip("install opencv-python", "Installing opencv-python...")
-
-if not launch.is_installed("numpy"):
-    launch.run_pip("install numpy", "Installing numpy...")
-
-if not launch.is_installed("Pillow"):
-    launch.run_pip("install Pillow", "Installing Pillow...")
-
-if not launch.is_installed("segmentation-refinement"):
-    launch.run_pip("install segmentation-refinement", "Installing segmentation-refinement...")
-
-if not launch.is_installed("scikit-learn"):
-    launch.run_pip("install scikit-learn", "Installing scikit-learn...")
-
-if not launch.is_installed("clip"):
-    launch.run_pip("install clip", "Installing clip...")
+for package in packages:
+    if not launch.is_installed(package):
+        launch.run_pip(f'install {package}', desc=package)
 
 if not launch.is_installed("segment_anything"):
-    launch.run_pip("install git+https://github.com/facebookresearch/segment-anything.git", "Installing segment_anything...")
+    launch.run_pip("install git+https://github.com/facebookresearch/segment-anything.git", desc="segment_anything")

--- a/install.py
+++ b/install.py
@@ -13,7 +13,7 @@ packages = [
 
 for package in packages:
     if not launch.is_installed(package):
-        launch.run_pip(f'install {package}', desc=package)
+        launch.run_pip(f'install {package}', desc=f'{package} for PBRemTools')
 
 if not launch.is_installed("segment_anything"):
     launch.run_pip("install git+https://github.com/facebookresearch/segment-anything.git", desc="segment_anything")

--- a/install.py
+++ b/install.py
@@ -16,4 +16,4 @@ for package in packages:
         launch.run_pip(f'install {package}', desc=f'{package} for PBRemTools')
 
 if not launch.is_installed("segment_anything"):
-    launch.run_pip("install git+https://github.com/facebookresearch/segment-anything.git", desc="segment_anything")
+    launch.run_pip("install git+https://github.com/facebookresearch/segment-anything.git", desc="segment_anything for PBRemTools")


### PR DESCRIPTION
## Why
latest commit's install dialog output like bellow
```
Installing Installing onnxruntime-gpu...
Installing Installing opencv-python...
Installing Installing Pillow...
Installing Installing segmentation-refinement...
Installing Installing scikit-learn...
```

## What
- fix duplicate dialog
- refactor package listing

```
Installing onnxruntime-gpu for PBRemTools
Installing opencv-python for PBRemTools
Installing Pillow for PBRemTools
Installing segmentation-refinement for PBRemTools
Installing scikit-learn for PBRemTools
```

## etc
cf. latest A1111 run_pip usage :wink: 
https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/72cd27a13587c9579942577e9e3880778be195f6/launch.py#L123-L128

