### PR TITLE
update gallery UI style for latest a1111

### DIFF
--- a/scripts/main.py
+++ b/scripts/main.py
@@ -138,7 +138,7 @@ def on_ui_tabs():
                 submit = gr.Button(value="Submit")
             with gr.Row():
                 with gr.Column():
-                    gallery = gr.Gallery(label="outputs", show_label=True, elem_id="gallery").style(grid=2)
+                    gallery = gr.Gallery(label="outputs", show_label=True, elem_id="gallery").style(grid=2, object_fit="contain")
 
         # 0: single 1: batch 2: batch dir
         input_tab_single.select(fn=lambda: 0, inputs=[], outputs=[input_tab_state])


### PR DESCRIPTION
# Why
- gallery ui is broken in latest a1111 1.2.1 (maybe by gradio side update)

<img src="https://github.com/mattyamonaca/PBRemTools/assets/128375799/db784abc-f135-4fe9-bbcf-abaa3fcad56f" width=500>

# What
- add style to fix
<img src="https://github.com/mattyamonaca/PBRemTools/assets/128375799/a0b61be3-ab78-426d-99c3-a340c6a6748d" width=500>



